### PR TITLE
feat(regex): expand URL validation to support internal domain patterns

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.5.0
+version: 0.5.1
 type: plugin
 author: watercrawl
 name: watercrawl

--- a/provider/water-crawl.py
+++ b/provider/water-crawl.py
@@ -35,8 +35,8 @@ class WaterCrawlProvider(ToolProvider):
         try:
             regex = re.compile(
                 r'^(https?:\/\/)+'  # http:// or https://
-                r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain...
-                r'localhost|'  # localhost...
+                r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # Public domain
+                r'(?:[a-z]([a-z0-9-]*[a-z0-9])?)|'   # Internal domain
                 r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
                 r'(?::\d+)?'  # optional port
                 r'(?:/?|[/?]\S+)$', re.IGNORECASE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin~=0.2.1
+dify_plugin~=0.4.3


### PR DESCRIPTION
- Added support for internal domain names (e.g., Docker/Kubernetes service names)
- Enables recognition of service discovery-style URLs in addition to public domains, localhost, and IP addresses
- Maintains existing support for optional ports and paths